### PR TITLE
Added IntelliJ files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ openproj_contrib/openproj-contrib.jar
 openproj_contrib/openproj-reports.jar
 openproj_contrib/openproj-script.jar
 openproj_contrib/tmp/
+
+# IntelliJ Files & Directories
+.idea/
+out/
+.settings/
+*.iml


### PR DESCRIPTION
I am going to be contributing to this project using IntelliJ IDEA. Just so there is no interference with development modules used for this project, I added the directories that come with creating an IntelliJ project like .idea, out, .settings. IntelliJ also has its own custom config files, which end with .iml. As seen on the .gitignore, these will all be excluded from the project preventing any problems with development for others who use other IDEs. 